### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,9 @@
 [![smithery badge](https://smithery.ai/badge/@NaveenBandarage/poke-mcp)](https://smithery.ai/server/@NaveenBandarage/poke-mcp)
+
+<a href="https://glama.ai/mcp/servers/@NaveenBandarage/poke-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@NaveenBandarage/poke-mcp/badge" alt="Poke-MCP MCP server" />
+</a>
+
 ## Overview
 
 Poke-MCP is a Model Context Protocol (MCP) server that provides Pokémon information through a standardized interface. It connects to the [PokeAPI](https://pokeapi.co/) to fetch Pokémon data and exposes it through MCP tools that can be used by any MCP-compatible client, such as Claude Desktop App, Continue, Cline, and others.


### PR DESCRIPTION
This PR adds a badge for the [Poke-MCP](https://glama.ai/mcp/servers/@NaveenBandarage/poke-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@NaveenBandarage/poke-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@NaveenBandarage/poke-mcp/badge" alt="Poke-MCP MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.